### PR TITLE
add POLICY_MAX_COVERAGE environment variable

### DIFF
--- a/main-api.tf
+++ b/main-api.tf
@@ -217,6 +217,7 @@ locals {
       USER_WELCOME_EMAIL_INTRO            = var.user_welcome_email_intro
       USER_WELCOME_EMAIL_PREVIEW_TEXT     = var.user_welcome_email_preview_text
       USER_WELCOME_EMAIL_ENDING           = var.user_welcome_email_ending
+      POLICY_MAX_COVERAGE                 = var.policy_max_coverage
     }
   )
 }

--- a/task-def-api.json
+++ b/task-def-api.json
@@ -200,6 +200,10 @@
       {
         "name": "USER_WELCOME_EMAIL_ENDING",
         "value": "${USER_WELCOME_EMAIL_ENDING}"
+      },
+      {
+        "name": "POLICY_MAX_COVERAGE",
+        "value": "${POLICY_MAX_COVERAGE}"
       }
     ],
     "ulimits": null,

--- a/vars.tf
+++ b/vars.tf
@@ -253,3 +253,9 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "policy_max_coverage" {
+  description = "The maximum coverage amount for a single policy, in US Dollars."
+  type        = number
+  default     = 50000
+}


### PR DESCRIPTION
### Added
- Added `POLICY_MAX_COVERAGE` environment variable with a default of $50,000, which is the same as the default in [cover-api](https://github.com/silinternational/cover-api/blob/059cc7825c13ca131784cfcdd40c6680de5b2e57/application/domain/domain.go#L181)

Issue: [CVR-656](https://itse.youtrack.cloud/issue/CVR-656)