### PR TITLE
Release - add POLICY_MAX_COVERAGE environment variable 

### DIFF
--- a/main-api.tf
+++ b/main-api.tf
@@ -200,8 +200,6 @@ locals {
       SAML_CHECK_RESPONSE_SIGNING         = var.saml_check_response_signing
       SAML_SIGN_REQUEST                   = var.saml_sign_request
       SAML_REQUIRE_ENCRYPTED_ASSERTION    = var.saml_require_encrypted_assertion
-      ROLLBAR_SERVER_ROOT                 = var.rollbar_server_root
-      ROLLBAR_TOKEN                       = var.rollbar_token
       SENTRY_DSN                          = var.sentry_dsn
       SESSION_SECRET                      = var.session_secret
       UI_URL                              = var.ui_url

--- a/main-api.tf
+++ b/main-api.tf
@@ -217,6 +217,7 @@ locals {
       USER_WELCOME_EMAIL_INTRO            = var.user_welcome_email_intro
       USER_WELCOME_EMAIL_PREVIEW_TEXT     = var.user_welcome_email_preview_text
       USER_WELCOME_EMAIL_ENDING           = var.user_welcome_email_ending
+      POLICY_MAX_COVERAGE                 = var.policy_max_coverage
     }
   )
 }

--- a/task-def-api.json
+++ b/task-def-api.json
@@ -200,6 +200,10 @@
       {
         "name": "USER_WELCOME_EMAIL_ENDING",
         "value": "${USER_WELCOME_EMAIL_ENDING}"
+      },
+      {
+        "name": "POLICY_MAX_COVERAGE",
+        "value": "${POLICY_MAX_COVERAGE}"
       }
     ],
     "ulimits": null,

--- a/task-def-api.json
+++ b/task-def-api.json
@@ -138,14 +138,6 @@
         "value": "${SAML_REQUIRE_ENCRYPTED_ASSERTION}"
       },
       {
-        "name": "ROLLBAR_SERVER_ROOT",
-        "value": "${ROLLBAR_SERVER_ROOT}"
-      },
-      {
-        "name": "ROLLBAR_TOKEN",
-        "value": "${ROLLBAR_TOKEN}"
-      },
-      {
         "name": "SENTRY_DSN",
         "value": "${SENTRY_DSN}"
       },

--- a/vars.tf
+++ b/vars.tf
@@ -58,11 +58,6 @@ variable "email_service" {
 variable "go_env" {
 }
 
-variable "rollbar_token" {
-  description = "Rollbar API token. Omit to disable rollbar logging."
-  default     = ""
-}
-
 variable "sentry_dsn" {
   description = "Sentry DSN for error logging. Omit to disable Sentry logging."
   default     = ""
@@ -164,10 +159,6 @@ variable "saml_sign_request" {
 
 variable "saml_require_encrypted_assertion" {
   default = "true"
-}
-
-variable "rollbar_server_root" {
-  default = "github.com/silinternational/cover-api"
 }
 
 variable "session_secret" {

--- a/vars.tf
+++ b/vars.tf
@@ -253,3 +253,9 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "policy_max_coverage" {
+  description = "The maximum coverage amount for a single policy, in US Dollars."
+  type        = number
+  default     = 50000
+}


### PR DESCRIPTION
### Added
- Added `POLICY_MAX_COVERAGE` environment variable with a default of $50,000, which is the same as the default in [cover-api](https://github.com/silinternational/cover-api/blob/059cc7825c13ca131784cfcdd40c6680de5b2e57/application/domain/domain.go#L181)

Issue: [CVR-656](https://itse.youtrack.cloud/issue/CVR-656)