### PR TITLE
CVR-797 -- add DNS records for email authentication

### DIFF
--- a/main-api.tf
+++ b/main-api.tf
@@ -360,16 +360,3 @@ resource "cloudflare_record" "dmarc" {
   comment = "DMARC record for ${local.email_domain}"
   tags    = local.cloudflare_tags
 }
-
-
-/*
- * Postmaster Tools DNS verification
- */
-resource "cloudflare_record" "postmaster_tools" {
-  name    = local.email_domain
-  type    = "TXT"
-  zone_id = data.cloudflare_zone.this.id
-  value   = "google-site-verification=GZpqhdd9TYF4RWBTQjZz4d86t6Helyhwdd6J1woQ3d4"
-  comment = "verification for Google Postmaster Tools"
-  tags    = local.cloudflare_tags
-}

--- a/main-api.tf
+++ b/main-api.tf
@@ -305,3 +305,14 @@ module "backup_rds" {
   notification_events  = var.backup_notification_events
   sns_topic_arn        = var.backup_sns_topic_arn
 }
+
+/*
+ * AWS SES email identity
+ */
+resource "aws_ses_email_identity" "this" {
+  email = var.email_from_address
+}
+import {
+  id = var.email_from_address
+  to = aws_ses_email_identity.this
+}

--- a/main-api.tf
+++ b/main-api.tf
@@ -339,7 +339,7 @@ resource "aws_ses_domain_dkim" "this" {
 }
 
 resource "cloudflare_record" "ses_dkim" {
-  count = 3
+  count = length(aws_ses_domain_dkim.this.dkim_tokens)
 
   name    = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}._domainkey.${local.email_domain}"
   type    = "CNAME"
@@ -356,7 +356,10 @@ resource "cloudflare_record" "dmarc" {
   name    = "_dmarc.${local.email_domain}"
   type    = "TXT"
   zone_id = data.cloudflare_zone.this.id
-  value   = "v=DMARC1; p=none; sp=reject" // no filtering on base domain, reject all for subdomains
+
+  // `p=none` means no filtering on base domain, `sp=reject` means reject all for subdomains
+  value = "v=DMARC1; p=none; sp=reject"
+
   comment = "DMARC record for ${local.email_domain}"
   tags    = local.cloudflare_tags
 }

--- a/main-api.tf
+++ b/main-api.tf
@@ -1,3 +1,13 @@
+
+locals {
+  tags = merge({
+    managed_by = "terraform"
+    workspace  = terraform.workspace
+  }, var.tags)
+  cloudflare_tags = [for k, v in local.tags : "${k}:${v}"]
+  email_domain    = split("@", var.email_from_address)[1]
+}
+
 locals {
   app_name_and_env = "${var.app_name}-${data.terraform_remote_state.common.outputs.app_env}"
   app_env          = data.terraform_remote_state.common.outputs.app_env
@@ -254,19 +264,16 @@ module "ecsapi" {
  * Create Cloudflare DNS record
  */
 resource "cloudflare_record" "dns" {
-  zone_id = data.cloudflare_zones.domain.zones[0].id
+  zone_id = data.cloudflare_zone.this.id
   name    = var.subdomain_api
   value   = data.terraform_remote_state.common.outputs.alb_dns_name
   type    = "CNAME"
   proxied = true
+  tags    = local.tags
 }
 
-data "cloudflare_zones" "domain" {
-  filter {
-    name        = var.cloudflare_domain
-    lookup_type = "exact"
-    status      = "active"
-  }
+data "cloudflare_zone" "this" {
+  name = var.cloudflare_domain
 }
 
 module "adminer" {
@@ -304,4 +311,52 @@ module "backup_rds" {
   backup_cron_schedule = var.backup_cron_schedule
   notification_events  = var.backup_notification_events
   sns_topic_arn        = var.backup_sns_topic_arn
+}
+
+
+/*
+ * SES configurations
+ */
+
+# TXT record for SPF
+resource "cloudflare_record" "ses_spf" {
+  name    = local.email_domain
+  type    = "TXT"
+  zone_id = data.cloudflare_zone.this.id
+  value   = "v=spf1 include:amazonses.com -all"
+  tags    = local.cloudflare_tags
+  comment = "SPF record for email authentication"
+}
+
+resource "aws_ses_domain_identity" "this" {
+  domain = local.email_domain
+}
+
+
+# DKIM records
+resource "aws_ses_domain_dkim" "this" {
+  domain = aws_ses_domain_identity.this.domain
+}
+
+resource "cloudflare_record" "ses_dkim" {
+  count = 3
+
+  name    = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}._domainkey"
+  type    = "CNAME"
+  zone_id = data.cloudflare_zone.this.id
+  value   = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}.dkim.amazonses.com"
+  tags    = local.cloudflare_tags
+  comment = "DMARC record for email authentication"
+}
+
+/*
+ * DMARC record
+ */
+resource "cloudflare_record" "dmarc" {
+  name    = "_dmarc.${local.email_domain}"
+  type    = "TXT"
+  zone_id = data.cloudflare_zone.this.id
+  value   = "v=DMARC1; p=none; sp=reject" // no filtering on base domain, reject all for subdomains
+  comment = "DMARC record for ${local.email_domain}"
+  tags    = local.cloudflare_tags
 }

--- a/main-api.tf
+++ b/main-api.tf
@@ -269,7 +269,7 @@ resource "cloudflare_record" "dns" {
   value   = data.terraform_remote_state.common.outputs.alb_dns_name
   type    = "CNAME"
   proxied = true
-  tags    = local.tags
+  tags    = local.cloudflare_tags
 }
 
 data "cloudflare_zone" "this" {

--- a/main-api.tf
+++ b/main-api.tf
@@ -341,7 +341,7 @@ resource "aws_ses_domain_dkim" "this" {
 resource "cloudflare_record" "ses_dkim" {
   count = 3
 
-  name    = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}._domainkey"
+  name    = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}._domainkey.${local.email_domain}"
   type    = "CNAME"
   zone_id = data.cloudflare_zone.this.id
   value   = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}.dkim.amazonses.com"

--- a/main-api.tf
+++ b/main-api.tf
@@ -339,7 +339,7 @@ resource "aws_ses_domain_dkim" "this" {
 }
 
 resource "cloudflare_record" "ses_dkim" {
-  count = length(aws_ses_domain_dkim.this.dkim_tokens)
+  count = 3
 
   name    = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}._domainkey.${local.email_domain}"
   type    = "CNAME"

--- a/main-api.tf
+++ b/main-api.tf
@@ -346,7 +346,7 @@ resource "cloudflare_record" "ses_dkim" {
   zone_id = data.cloudflare_zone.this.id
   value   = "${element(aws_ses_domain_dkim.this.dkim_tokens, count.index)}.dkim.amazonses.com"
   tags    = local.cloudflare_tags
-  comment = "DMARC record for email authentication"
+  comment = "DKIM record for email authentication"
 }
 
 /*

--- a/main-api.tf
+++ b/main-api.tf
@@ -360,3 +360,16 @@ resource "cloudflare_record" "dmarc" {
   comment = "DMARC record for ${local.email_domain}"
   tags    = local.cloudflare_tags
 }
+
+
+/*
+ * Postmaster Tools DNS verification
+ */
+resource "cloudflare_record" "postmaster_tools" {
+  name    = local.email_domain
+  type    = "TXT"
+  zone_id = data.cloudflare_zone.this.id
+  value   = "google-site-verification=GZpqhdd9TYF4RWBTQjZz4d86t6Helyhwdd6J1woQ3d4"
+  comment = "verification for Google Postmaster Tools"
+  tags    = local.cloudflare_tags
+}

--- a/main-api.tf
+++ b/main-api.tf
@@ -305,14 +305,3 @@ module "backup_rds" {
   notification_events  = var.backup_notification_events
   sns_topic_arn        = var.backup_sns_topic_arn
 }
-
-/*
- * AWS SES email identity
- */
-resource "aws_ses_email_identity" "this" {
-  email = var.email_from_address
-}
-import {
-  id = var.email_from_address
-  to = aws_ses_email_identity.this
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,13 +14,13 @@ output "api_url" {
   value = "https://${var.subdomain_api}.${var.cloudflare_domain}"
 }
 
-output "aws_ses_access_key_id" {
-  description = "access key for SES (internal and Auth0) and S3 (attachments)"
+output "aws_cover_access_key_id" {
+  description = "access key for SES (internal and Auth0), S3 (attachments), and SSM"
   value       = aws_iam_access_key.cover.id
 }
 
-output "aws_ses_secret_access_key" {
-  description = "access key secret for SES (internal and Auth0) and S3 (attachments)"
+output "aws_cover_secret_access_key" {
+  description = "access key secret for SES (internal and Auth0), S3 (attachments), and SSM"
   value       = aws_iam_access_key.cover.secret
   sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,3 +50,15 @@ output "bkup_cron_schedule" {
 output "backup_notification_events" {
   value = var.enable_db_backup ? join(", ", var.backup_notification_events) : ""
 }
+
+
+/*
+ * Output message
+ */
+
+output "message" {
+  value = join("\n", [<<-EOT
+    Tags for SES Verified Identity are not added automatically. If not already added, add these tags in the AWS Console:
+    EOT
+  ], [for k, v in local.tags : format("%s: %s", k, v)])
+}

--- a/vars.tf
+++ b/vars.tf
@@ -34,9 +34,11 @@ variable "adminer_plugins" {
 }
 
 variable "aws_access_key" {
+  default = null
 }
 
 variable "aws_secret_key" {
+  default = null
 }
 
 variable "aws_s3_bucket" {
@@ -44,6 +46,7 @@ variable "aws_s3_bucket" {
 
 variable "cloudflare_token" {
   description = "Limited access token for DNS updates"
+  default     = null
 }
 
 variable "cloudflare_domain" {


### PR DESCRIPTION
### Added
- Add tags to Cloudflare records
- Add comments to Cloudflare records
- Add SPF record
- Add DKIM records (already present, but not managed by Terraform)
- Add DMARC record 
- Added an output message as a reminder to add AWS tags for SES verified identity
- Added `default = null` to provider inputs to allow for the values to be provided by environment variables when working on the command line.

### Changed
- Use `cloudflare_zone` instead of the more complex `cloudflare_zones` data resource
- Rename outputs `aws_ses_access_key_id` and `aws_ses_secret_access_key` to `aws_cover_access_key_id` and `aws_cover_secret_access_key`. Corresponds to an earlier change.

[CVR-797](https://itse.youtrack.cloud/issue/CVR-797)