### PR TITLE
Clone AWS S3 data bucket to Backblaze B2 bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -627,8 +627,8 @@ resource "aws_iam_user_policy" "clone" {
       {
         Effect = "Allow"
         Action = [
-          "s3:GetObject"
-        ],
+          "s3:GetObject",
+        ]
         Resource = "${data.aws_s3_bucket.s3_data_bucket.arn}/*"
       }
     ]
@@ -660,7 +660,7 @@ locals {
 }
 
 /*
- * Create role for scheduled running of cron task definitions.
+ * Create role for scheduled running of rclone task definition.
  */
 resource "aws_iam_role" "rclone_event" {
   name = "rclone_event-${var.app_name}-${local.app_env}-s3copy"
@@ -702,7 +702,7 @@ resource "aws_iam_role_policy" "rclone_event_run_task_with_any_role" {
 }
 
 /*
- * Create cron task definition
+ * Create bucket clone task definition
  */
 resource "aws_ecs_task_definition" "clone_cron_td" {
   family                = "${var.app_name}-clone-${local.app_env}"

--- a/main.tf
+++ b/main.tf
@@ -599,3 +599,136 @@ resource "aws_cloudwatch_event_target" "backup_event_target" {
   }
 }
 
+/*
+ * Get details about the S3 bucket we are backing up
+ */
+data "aws_s3_bucket" "s3_data_bucket" {
+  bucket = var.aws_s3_bucket
+}
+
+/*
+ * Create user for getting files from the bucket
+ */
+resource "aws_iam_user" "clone" {
+  name = "s3-clone-${var.app_name}-${local.app_env}"
+}
+
+resource "aws_iam_access_key" "clone" {
+  user = aws_iam_user.clone.name
+}
+
+resource "aws_iam_user_policy" "clone" {
+  name = "S3-Clone-Backup"
+  user = aws_iam_user.clone.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject"
+        ],
+        Resource = "${data.aws_s3_bucket.s3_data_bucket.arn}/*"
+      }
+    ]
+  })
+}
+
+/*
+ * Create ECS service container definition
+ */
+locals {
+  task_def_clone = templatefile("${path.module}/task-def-copys3b2.json", {
+    app_name              = var.app_name
+    aws_access_key        = aws_iam_access_key.backup.id
+    aws_secret_key        = aws_iam_access_key.backup.secret
+    aws_region            = var.aws_region
+    b2_application_key_id = var.b2_application_key_id
+    b2_application_key    = var.b2_application_key
+    s3_bucket             = var.aws_s3_bucket
+    s3_path               = var.s3_path
+    b2_bucket             = var.b2_bucket
+    b2_path               = var.b2_path
+    rclone_arguments      = var.rclone_arguments
+    log_group_name        = aws_cloudwatch_log_group.cover.name
+    cpu                   = var.backup_cpu
+    docker_image          = var.s3_backup_docker_image
+    docker_tag            = var.s3_backup_docker_tag
+    memory                = var.backup_memory
+  })
+}
+
+/*
+ * Create role for scheduled running of cron task definitions.
+ */
+resource "aws_iam_role" "rclone_event" {
+  name = "rclone_event-${var.app_name}-${local.app_env}-s3copy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = ""
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "rclone_event_run_task_with_any_role" {
+  name = "rclone_event_run_task_with_any_role"
+  role = aws_iam_role.rclone_event.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = "${aws_ecs_task_definition.clone_cron_td.arn_without_revision}:*"
+      }
+    ])
+  })
+}
+
+/*
+ * Create cron task definition
+ */
+resource "aws_ecs_task_definition" "clone_cron_td" {
+  family                = "${var.app_name}-clone-${local.app_env}"
+  container_definitions = local.task_def_clone
+  network_mode          = "bridge"
+}
+
+/*
+ * CloudWatch configuration to start scheduled backup of S3 using rclone.
+ */
+resource "aws_cloudwatch_event_rule" "s3_clone_event_rule" {
+  name        = "${var.app_name}-${local.app_env}-s3clone"
+  description = "Start scheduled backup of S3 using rclone"
+
+  schedule_expression = var.s3_clone_schedule
+}
+
+resource "aws_cloudwatch_event_target" "clone_event_target" {
+  target_id = "${var.app_name}-${local.app_env}-s3clone"
+  rule      = aws_cloudwatch_event_rule.s3_clone_event_rule.name
+  arn       = data.terraform_remote_state.common.outputs.ecs_cluster_id
+  role_arn  = aws_iam_role.rclone_event.arn
+
+  ecs_target {
+    task_count          = 1
+    launch_type         = "EC2"
+    task_definition_arn = aws_ecs_task_definition.clone_cron_td.arn
+  }
+}

--- a/task-def-copys3b2.json
+++ b/task-def-copys3b2.json
@@ -1,0 +1,78 @@
+[
+  {
+    "dnsSearchDomains": null,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group_name}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "${app_name}"
+      }
+    },
+    "entryPoint": null,
+    "portMappings": [],
+    "command": [],
+    "cpu": ${cpu},
+    "environment": [
+      {
+        "name": "AWS_ACCESS_KEY",
+        "value": "${aws_access_key}"
+      },
+      {
+        "name": "AWS_SECRET_KEY",
+        "value": "${aws_secret_key}"
+      },
+      {
+        "name": "AWS_REGION",
+        "value": "${aws_region}"
+      },
+      {
+        "name": "B2_APPLICATION_KEY_ID",
+        "value": "${b2_application_key_id}"
+      },
+      {
+        "name": "B2_APPLICATION_KEY",
+        "value": "${b2_application_key}"
+      },
+      {
+        "name": "S3_BUCKET",
+        "value": "${s3_bucket}"
+      },
+      {
+        "name": "S3_PATH",
+        "value": "${s3_path}"
+      },
+      {
+        "name": "B2_BUCKET",
+        "value": "${b2_bucket}"
+      },
+      {
+        "name": "B2_PATH",
+        "value": "${b2_path}"
+      },
+      {
+        "name": "RCLONE_ARGUMENTS",
+        "value": "${rclone_arguments}"
+      }
+    ],
+    "ulimits": null,
+    "dnsServers": null,
+    "mountPoints": [],
+    "workingDirectory": null,
+    "dockerSecurityOptions": null,
+    "memory": null,
+    "memoryReservation": ${memory},
+    "volumesFrom": [],
+    "image": "${docker_image}:${docker_tag}",
+    "disableNetworking": null,
+    "essential": true,
+    "links": null,
+    "hostname": null,
+    "extraHosts": null,
+    "user": null,
+    "readonlyRootFilesystem": null,
+    "dockerLabels": null,
+    "privileged": null,
+    "name": "rclone"
+  }
+]

--- a/vars.tf
+++ b/vars.tf
@@ -360,11 +360,15 @@ variable "db_backup_docker_tag" {
 }
 
 variable "s3_backup_docker_image" {
-  default = "silintl/sync-s3-to-b2"
+  description = "Docker image for the S3-to-B2 backup task"
+  type        = string
+  default     = "silintl/sync-s3-to-b2"
 }
 
 variable "s3_backup_docker_tag" {
-  default = "1.0.0"
+  description = "Docker tag for the S3-to-B2 backup task"
+  type        = string
+  default     = "1.0.0"
 }
 
 variable "db_options" {
@@ -386,19 +390,25 @@ variable "db_backup_service_mode" {
 }
 
 variable "rclone_arguments" {
+  description = "(optional) e.g., --combined -"
   type        = string
   default     = ""
-  description = "(optional) e.g., --combined -"
 }
 
 variable "s3_path" {
-  default = "*"
+  description = "Path to be backed up within the AWS S3 bucket"
+  type        = string
+  default     = "*"
 }
 
 variable "b2_path" {
-  default = "s3_backup"
+  description = "Path within the Backblaze B2 bucket where files will be stored"
+  type        = string
+  default     = "s3_backup"
 }
 
 variable "s3_clone_schedule" {
-  default = "cron(10 2 * * ? *)"
+  description = "S3-to-B2 backup schedule"
+  type        = string
+  default     = "cron(10 2 * * ? *)" # Every day at 02:10 UTC
 }

--- a/vars.tf
+++ b/vars.tf
@@ -316,7 +316,7 @@ variable "github_repository" {
 }
 
 /*
- * Variables to support database backups
+ * Variables to support database and S3 backups
  */
 
 variable "b2_application_key_id" {
@@ -359,6 +359,14 @@ variable "db_backup_docker_tag" {
   default = "4.0.0"
 }
 
+variable "s3_backup_docker_image" {
+  default = "silintl/sync-s3-to-b2"
+}
+
+variable "s3_backup_docker_tag" {
+  default = "1.0.0"
+}
+
 variable "db_options" {
   type        = string
   default     = ""
@@ -375,4 +383,22 @@ variable "db_backup_s3_bucket" {
 
 variable "db_backup_service_mode" {
   default = "backup"
+}
+
+variable "rclone_arguments" {
+  type        = string
+  default     = ""
+  description = "(optional) e.g., --combined -"
+}
+
+variable "s3_path" {
+  default = "*"
+}
+
+variable "b2_path" {
+  default = "s3_backup"
+}
+
+variable "s3_clone_schedule" {
+  default = "cron(10 2 * * ? *)"
 }


### PR DESCRIPTION
## Added

* Use `silintl/sync-s3-to-b2` to copy the attachments stored in AWS S3 to Backblaze B2.